### PR TITLE
Add exceptions to "and the NSA"

### DIFF
--- a/selectors-www.facebook.com.json
+++ b/selectors-www.facebook.com.json
@@ -22,7 +22,7 @@
         }
     },
     {
-        "selector": "ul[role='menu'] [role='menuitem'] span:last-child",
+        "selector": "ul[role='menu'] li:not(:nth-child(2)):not(:nth-child(6)):not([aria-haspopup]) [role='menuitem'] i + span[class]:last-child",
         "action": "appendText",
         "content": {
             "en-US": " and the NSA"


### PR DESCRIPTION
Adds an "exceptions" field to "and the NSA" object.
Adds a if clause to .js file that checks for and jumps over exceptions

Looks like this:
![nsaexception2](https://cloud.githubusercontent.com/assets/6193262/16065768/7f5f59be-327b-11e6-8a66-8fce8817e3ac.png)
![nsaexceptions](https://cloud.githubusercontent.com/assets/6193262/16065769/7f61357c-327b-11e6-99e2-1b2af86e7dd0.png)

Justification:
- "Public and the NSA" is redundant because the public includes the NSA.
- "More Options and the NSA" and "Custom and the NSA" don't make sense.